### PR TITLE
Fix CRC8 DARC and CRC32 JAMCRC docs

### DIFF
--- a/src/crc_u32.rs
+++ b/src/crc_u32.rs
@@ -671,7 +671,7 @@ impl CRCu32 {
 
     /// |Check|Poly|Init|Ref|XorOut|
     /// |---|---|---|---|---|
-    /// |0x340BC6D9|0x04C11DB7 (rev: 0xEDB88320)|0x00000000|true|0x00000000|
+    /// |0x340BC6D9|0x04C11DB7 (rev: 0xEDB88320)|0xFFFFFFFF|true|0x00000000|
     ///
     /// ```
     /// # extern crate crc_any;

--- a/src/crc_u8.rs
+++ b/src/crc_u8.rs
@@ -497,7 +497,7 @@ impl CRCu8 {
 
     /// |Check|Poly|Init|Ref|XorOut|
     /// |---|---|---|---|---|
-    /// |0xDA|0x39 (rev: 0x9C)|0x00|true|0x00|
+    /// |0x15|0x39 (rev: 0x9C)|0x00|true|0x00|
     ///
     /// ```
     /// # extern crate crc_any;


### PR DESCRIPTION
The docs of both of these are slightly wrong.

JAMCRC: Initial is 0xFFFFFFFF, not 0. Code uses 0xFFFFFFFF. Confirmation source: https://reveng.sourceforge.io/crc-catalogue/17plus.htm#crc.cat.crc-32-jamcrc

DARC: Check value is 0x15, not 0xDA. Listed properly lower in the doc. Confirmation: https://reveng.sourceforge.io/crc-catalogue/1-15.htm#crc.cat.crc-8-darc