### PR TITLE
update to `heapless=0.8`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.3"
 optional = true
 
 [dependencies.heapless]
-version = "0.7"
+version = "0.8"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
the MSRV bump is needed due to heapless using newer features. 1.60 has been determined using [`cargo-msrv`] (note that heapless does not specify an MSRV, as per [their MSRV policy][MSRV-heapless]).

note that the MSRV has now already been done in 326e2a6 by @magiclen, so it is no longer included in this commit.

[`cargo-msrv`]: https://github.com/foresterre/cargo-msrv
[MSRV-heapless]: https://docs.rs/heapless/latest/heapless/#minimum-supported-rust-version-msrv