### PR TITLE
enable GitHub Dependabot for Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
this ensures that the dependencies are kept up to date. see [the docs] for further information.
so far only GitHub Actions were updated, now also Cargo/Rust dependencies will be updated by dependabot.

if this were enabled PRs like #11 wouldn't have to be created manually.

[the docs]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates